### PR TITLE
Separate the generated css to it's own file and avoid versioning it in github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 .sass-cache
+assets/css/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
                 tasks: ['jshint', 'uglify']
             },
             livereload: {
-                files: ['*.css', 'assets/js/*.js', '*.html', '*.php', 'assets/images/**/*.{png,jpg,jpeg,gif,webp,svg}'],
+                files: ['*.css', 'assets/css/*.css', 'assets/js/*.js', '*.html', '*.php', 'assets/images/**/*.{png,jpg,jpeg,gif,webp,svg}'],
                 tasks: ['livereload']
             }
         },

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1,14 +1,3 @@
-/*!
-Theme Name: WordPress Starter Theme
-Theme URI: http://www.THEME.com
-Description: WordPress Starter Theme for use as a starting template for building custom themes.
-Author: Matt Banks
-Author URI: http://www.kernelcreativemedia.com
-License: GNU General Public License v2.0
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Version: 1.0
-*/
-
 // Compass imports
 @import "compass";
 

--- a/config.rb
+++ b/config.rb
@@ -2,7 +2,7 @@
 
 # Set this to the root of your project when deployed:
 http_path = "/"
-css_dir = "/"
+css_dir = "assets/css"
 sass_dir = "assets/scss"
 images_dir = "assets/images"
 javascripts_dir = "assets/js"

--- a/style.css
+++ b/style.css
@@ -1,0 +1,11 @@
+/*!
+Theme Name: WordPress Starter Theme
+Theme URI: http://www.THEME.com
+Description: WordPress Starter Theme for use as a starting template for building custom themes.
+Author: Matt Banks
+Author URI: http://www.kernelcreativemedia.com
+License: GNU General Public License v2.0
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Version: 1.0
+*/
+@import url("assets/css/style.css");


### PR DESCRIPTION
Style.css is required by wordpress since it's beginning comment holds the theme's information. But, if we're using grunt compass to generate the style.css, the rest of the file is generated css which is an artifact. The information is already contained in the assets/scss/style.scss file. 

I propose we have grunt compass generate assets/css/style.css and have ./style.css include that. that way ./style.css just has the Theme information part and the generated css is .gitignored. 

This does not affect someone who wants to just code in css. They can edit ./style.css at will.  They would just need to avoid running grunt compass or make sure that they don't collide with asssets/css/style.css for an imported file. That seems unlikely or easily fixed.

This does mean an extra step before installing this theme,  and that's running grunt compass once. But since that's the point of this setup, that seems acceptable.
