### PR TITLE
prevent redefinition of DISALLOW_FILE_EDIT constant

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -55,7 +55,9 @@ function _mbbasetheme_setup() {
 	add_editor_style();
 
 	// Prevent File Modifications
-	define ( 'DISALLOW_FILE_EDIT', true );
+	if ( ! defined( 'DISALLOW_FILE_EDIT' ) ) {
+		define( 'DISALLOW_FILE_EDIT', true );
+	}
 
 	// Enable support for Post Thumbnails on posts and pages.
 	add_theme_support( 'post-thumbnails' );


### PR DESCRIPTION
in my use case this constant is already defined (as a part of Wordpress stack default settings).
