### PR TITLE
Typo : "mbbasetheme" instead of "_mbbasetheme"

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -41,7 +41,7 @@ function _mbbasetheme_setup() {
 
 	// Register nav menus
 	register_nav_menus( array(
-		'primary' => __( 'Primary Menu', 'mbbasetheme' ),
+		'primary' => __( 'Primary Menu', '_mbbasetheme' ),
 	) );
 
 	// Register Widget Areas


### PR DESCRIPTION
This should also be replaced when renaming the theme from "_mbbasetheme" to a custom name